### PR TITLE
Fix setup.cfg and bump version to 2.0.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.md
+description_file = README.md
 
 [flake8]
 max-line-length = 120

--- a/tls_parser/__init__.py
+++ b/tls_parser/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 __author__ = "Alban Diquet"
 __email__ = "nabla.c0d3@gmail.com"
 


### PR DESCRIPTION
Hey,

This PR fixes the setup issue with `setuptools>=78.0.0` (as mentioned here: https://github.com/nabla-c0d3/tls_parser/issues/10).

Ideally, it would be nice to bump the tls-parser dependency on sslyze too.

edit: no need to update sslyze thanks to semver: https://github.com/nabla-c0d3/sslyze/blob/release/setup.py#L103

Thanks!