### PR TITLE
Update meta information

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,16 @@ setup(
     author=__author__,
     author_email=__email__,
     url="https://github.com/nabla-c0d3/tls_parser",
+    classifiers=[
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+    ],
     packages=["tls_parser"],
     python_requires=">=3.8",
 )


### PR DESCRIPTION
Code analysis tools raise errors that tls_parser has no license. These tools are determine the "declared license" for Python (PyPI) packages by reading the license information from the package metadata.

If the license is not properly declared in this metadata (for example, if the License field is missing or set to unknown), the tools will report the license as "Not Declared"—even if the GitHub repository contains a LICENSE file or the license is clearly stated elsewhere.